### PR TITLE
Better Typing - Compound Variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phntms/css-components",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@phntms/css-components",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phntms/css-components",
   "description": "At its core, css-components is a simple wrapper around standard CSS. It allows you to write your CSS how you wish then compose them into a component ready to be used in React.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "homepage": "https://github.com/phantomstudios/css-components#readme",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ const findMatchingCompoundVariants = (
     )
   );
 
+const flattenCss = (css: cssType) => (Array.isArray(css) ? css.join(" ") : css);
+
 // Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
 // A more precise version of just React.ComponentPropsWithoutRef on its own
 export type PropsOf<
@@ -76,10 +78,7 @@ export const styled = <
       if (props.className) componentStyles.push(props.className);
 
       // Add the base style(s)
-      if (config?.css)
-        componentStyles.push(
-          Array.isArray(config.css) ? config.css.join(" ") : config.css
-        );
+      if (config?.css) componentStyles.push(flattenCss(config.css));
 
       // Pass through the ref
       if (ref) componentProps.ref = ref;
@@ -92,9 +91,7 @@ export const styled = <
             const selector = variant[
               mergedProps[key] as keyof typeof variant
             ] as cssType;
-            componentStyles.push(
-              Array.isArray(selector) ? selector.join(" ") : selector
-            );
+            componentStyles.push(flattenCss(selector));
           }
         } else {
           componentProps[key] = props[key];

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ type variantsType = Partial<{
   [key: string]: { [key: string | number]: cssType };
 }>;
 
-type compoundVariantType<V> = {
+type VariantOptions<V> = {
   [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
-} & {
+};
+
+type CompoundVariantType<V> = VariantOptions<V> & {
   css: cssType;
 };
 
@@ -48,7 +50,7 @@ export type PropsOf<
 interface Config<V> {
   css?: cssType;
   variants?: V;
-  compoundVariants?: compoundVariantType<V>[];
+  compoundVariants?: CompoundVariantType<V>[];
   defaultVariants?: {
     [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
   };
@@ -122,8 +124,6 @@ export const styled = <
   );
 
   return styledComponent as React.FC<
-    React.ComponentProps<E> & {
-      [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
-    }
+    React.ComponentProps<E> & VariantOptions<V>
   >;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,21 @@
-import { createElement, forwardRef, JSXElementConstructor } from "react";
+import { createElement, forwardRef } from "react";
 
-import { Config, cssType, PolymorphicComponent, variantsType } from "./type";
+import {
+  CSSComponentConfig,
+  cssType,
+  PolymorphicComponent,
+  variantsType,
+} from "./type";
 import { findMatchingCompoundVariants, flattenCss } from "./utils";
 
-export type CSSComponentPropType<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
-  P extends keyof React.ComponentProps<C>
-> = React.ComponentProps<C>[P];
+export { CSSComponentConfig, CSSComponentPropType } from "./type";
 
 export const styled = <
   V extends variantsType | object,
   E extends React.ElementType
 >(
   element: E,
-  config?: Config<V>
+  config?: CSSComponentConfig<V>
 ) => {
   const styledComponent = forwardRef<E, { [key: string]: string }>(
     (props, ref) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,17 +6,19 @@ export type CSSComponentPropType<
   P extends keyof React.ComponentProps<C>
 > = React.ComponentProps<C>[P];
 
+type cssType = string | string[];
+
 type variantValue = string | number | boolean | string[];
 
 // An object of variants, and how they map to CSS styles
 type variantsType = Partial<{
-  [key: string]: { [key: string | number]: string | string[] };
+  [key: string]: { [key: string | number]: cssType };
 }>;
 
-type compoundVariantType = {
-  [key: string]: variantValue;
+type compoundVariantType<V> = {
+  [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
 } & {
-  css: string | string[];
+  css: cssType;
 };
 
 // Does the type being passed in look like a boolean? If so, return the boolean.
@@ -44,9 +46,9 @@ export type PropsOf<
 > = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
 
 interface Config<V> {
-  css?: string | string[];
+  css?: cssType;
   variants?: V;
-  compoundVariants?: compoundVariantType[];
+  compoundVariants?: compoundVariantType<V>[];
   defaultVariants?: {
     [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
   };
@@ -71,14 +73,14 @@ export const styled = <
       // Pass through an existing className if it exists
       if (props.className) componentStyles.push(props.className);
 
-      // Pass through the ref
-      if (ref) componentProps.ref = ref;
-
       // Add the base style(s)
       if (config?.css)
         componentStyles.push(
           Array.isArray(config.css) ? config.css.join(" ") : config.css
         );
+
+      // Pass through the ref
+      if (ref) componentProps.ref = ref;
 
       // Apply any variant styles
       Object.keys(mergedProps).forEach((key) => {
@@ -87,7 +89,7 @@ export const styled = <
           if (variant && variant.hasOwnProperty(mergedProps[key])) {
             const selector = variant[
               mergedProps[key] as keyof typeof variant
-            ] as string | string[];
+            ] as cssType;
             componentStyles.push(
               Array.isArray(selector) ? selector.join(" ") : selector
             );

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import {
   cssType,
   PolymorphicComponent,
   variantsType,
-  variantValue,
 } from "./type";
 
 export type CSSComponentPropType<
@@ -14,22 +13,6 @@ export type CSSComponentPropType<
   C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
   P extends keyof React.ComponentProps<C>
 > = React.ComponentProps<C>[P];
-
-const findMatchingCompoundVariants = (
-  compoundVariants: {
-    [key: string]: variantValue;
-  }[],
-  props: {
-    [key: string]: variantValue;
-  }
-) =>
-  compoundVariants.filter((compoundVariant) =>
-    Object.keys(compoundVariant).every(
-      (key) => key === "css" || compoundVariant[key] === props[key]
-    )
-  );
-
-const flattenCss = (css: cssType) => (Array.isArray(css) ? css.join(" ") : css);
 
 interface Config<V> {
   css?: cssType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
 import { createElement, forwardRef, JSXElementConstructor } from "react";
 
-import {
-  BooleanIfStringBoolean,
-  CompoundVariantType,
-  cssType,
-  PolymorphicComponent,
-  variantsType,
-} from "./type";
+import { Config, cssType, PolymorphicComponent, variantsType } from "./type";
 import { findMatchingCompoundVariants, flattenCss } from "./utils";
 
 export type CSSComponentPropType<
@@ -14,15 +8,6 @@ export type CSSComponentPropType<
   C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
   P extends keyof React.ComponentProps<C>
 > = React.ComponentProps<C>[P];
-
-interface Config<V> {
-  css?: cssType;
-  variants?: V;
-  compoundVariants?: CompoundVariantType<V>[];
-  defaultVariants?: {
-    [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
-  };
-}
 
 export const styled = <
   V extends variantsType | object,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,21 @@
 import { createElement, forwardRef, JSXElementConstructor } from "react";
 
+import {
+  BooleanIfStringBoolean,
+  CompoundVariantType,
+  cssType,
+  PolymorphicComponent,
+  PolymorphicComponentPropsWithRef,
+  VariantOptions,
+  variantsType,
+  variantValue,
+} from "./type";
+
 export type CSSComponentPropType<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
   P extends keyof React.ComponentProps<C>
 > = React.ComponentProps<C>[P];
-
-type cssType = string | string[];
-
-type variantValue = string | number | boolean | string[];
-
-// An object of variants, and how they map to CSS styles
-type variantsType = Partial<{
-  [key: string]: { [key: string | number]: cssType };
-}>;
-
-type VariantOptions<V> = {
-  [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
-};
-
-type CompoundVariantType<V> = VariantOptions<V> & {
-  css: cssType;
-};
-
-// Does the type being passed in look like a boolean? If so, return the boolean.
-type BooleanIfStringBoolean<T> = T extends "true" | "false" ? boolean : T;
 
 const findMatchingCompoundVariants = (
   compoundVariants: {
@@ -41,13 +32,6 @@ const findMatchingCompoundVariants = (
   );
 
 const flattenCss = (css: cssType) => (Array.isArray(css) ? css.join(" ") : css);
-
-// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
-// A more precise version of just React.ComponentPropsWithoutRef on its own
-export type PropsOf<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
 
 interface Config<V> {
   css?: cssType;
@@ -120,7 +104,5 @@ export const styled = <
     }
   );
 
-  return styledComponent as React.FC<
-    React.ComponentProps<E> & VariantOptions<V>
-  >;
+  return styledComponent as PolymorphicComponent<E, V>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   PolymorphicComponent,
   variantsType,
 } from "./type";
+import { findMatchingCompoundVariants, flattenCss } from "./utils";
 
 export type CSSComponentPropType<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,6 @@ import {
   CompoundVariantType,
   cssType,
   PolymorphicComponent,
-  PolymorphicComponentPropsWithRef,
-  VariantOptions,
   variantsType,
   variantValue,
 } from "./type";

--- a/src/type.ts
+++ b/src/type.ts
@@ -5,6 +5,8 @@
  * Much respect
  */
 
+import { JSXElementConstructor } from "react";
+
 // Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
 // A more precise version of just React.ComponentPropsWithoutRef on its own
 export type PropsOf<
@@ -58,7 +60,7 @@ export type PolymorphicComponent<
 /**
  * The CSS Component Config type.
  */
-export interface Config<V> {
+export interface CSSComponentConfig<V> {
   css?: cssType;
   variants?: V;
   compoundVariants?: CompoundVariantType<V>[];
@@ -66,6 +68,15 @@ export interface Config<V> {
     [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
   };
 }
+
+/**
+ * Allows you to extract a type for variant values.
+ */
+export type CSSComponentPropType<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
+  P extends keyof React.ComponentProps<C>
+> = React.ComponentProps<C>[P];
 
 /**
  * CSS can be passed in as either a string or an array of strings.

--- a/src/type.ts
+++ b/src/type.ts
@@ -56,7 +56,7 @@ export type PolymorphicComponent<
 > = React.FC<PolymorphicComponentPropsWithRef<E, VariantOptions<V>>>;
 
 /**
- * CSS cam be passed in as either a string or an array of strings.
+ * CSS can be passed in as either a string or an array of strings.
  */
 export type cssType = string | string[];
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,9 @@
-// Mostly lifted from here: https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
+/**
+ * Mostly lifted from here:
+ * https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
+ *
+ * Much respect
+ */
 
 // Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
 // A more precise version of just React.ComponentPropsWithoutRef on its own
@@ -40,16 +45,26 @@ export type PolymorphicComponentPropsWithRef<
   Props = Record<string, unknown>
 > = PolymorphicComponentProps<C, Props> & { ref?: PolymorphicRef<C> };
 
+/**
+ * Pass in an element type `E` and a variants `V` and get back a
+ * type that can be used to create a component.
+ */
+
 export type PolymorphicComponent<
   E extends React.ElementType,
   V extends variantsType | object
 > = React.FC<PolymorphicComponentPropsWithRef<E, VariantOptions<V>>>;
 
+/**
+ * CSS cam be passed in as either a string or an array of strings.
+ */
 export type cssType = string | string[];
 
 export type variantValue = string | number | boolean | string[];
 
-// An object of variants, and how they map to CSS styles
+/**
+ * An object of variants, and how they map to CSS styles
+ */
 export type variantsType = Partial<{
   [key: string]: { [key: string | number]: cssType };
 }>;

--- a/src/type.ts
+++ b/src/type.ts
@@ -3,6 +3,7 @@
 // Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
 // A more precise version of just React.ComponentPropsWithoutRef on its own
 export type PropsOf<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
 > = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,75 @@
+// Mostly lifted from here: https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
+
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just React.ComponentPropsWithoutRef on its own
+export type PropsOf<
+  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
+
+/**
+ * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
+ * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
+ * set of props.
+ */
+export type ExtendableProps<
+  ExtendedProps = Record<string, unknown>,
+  OverrideProps = Record<string, unknown>
+> = OverrideProps & Omit<ExtendedProps, keyof OverrideProps>;
+
+/**
+ * Allows for inheriting the props from the specified element type so that
+ * props like children, className & style work, as well as element-specific
+ * attributes like aria roles. The component (`C`) must be passed in.
+ */
+export type InheritableElementProps<
+  C extends React.ElementType,
+  Props = Record<string, unknown>
+> = ExtendableProps<PropsOf<C>, Props>;
+
+export type PolymorphicRef<C extends React.ElementType> =
+  React.ComponentPropsWithRef<C>["ref"];
+
+export type PolymorphicComponentProps<
+  C extends React.ElementType,
+  Props = Record<string, unknown>
+> = InheritableElementProps<C, Props>;
+
+export type PolymorphicComponentPropsWithRef<
+  C extends React.ElementType,
+  Props = Record<string, unknown>
+> = PolymorphicComponentProps<C, Props> & { ref?: PolymorphicRef<C> };
+
+export type PolymorphicComponent<
+  E extends React.ElementType,
+  V extends variantsType | object
+> = React.FC<PolymorphicComponentPropsWithRef<E, VariantOptions<V>>>;
+
+export type cssType = string | string[];
+
+export type variantValue = string | number | boolean | string[];
+
+// An object of variants, and how they map to CSS styles
+export type variantsType = Partial<{
+  [key: string]: { [key: string | number]: cssType };
+}>;
+
+/**
+ * Returns a boolean type if a "true" or "false" string type is passed in.
+ */
+export type BooleanIfStringBoolean<T> = T extends "true" | "false"
+  ? boolean
+  : T;
+
+/**
+ * Returns a type object containing the variants and their possible values.
+ */
+export type VariantOptions<V> = {
+  [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
+};
+
+/**
+ * Returns a type object for compound variants.
+ */
+export type CompoundVariantType<V> = VariantOptions<V> & {
+  css: cssType;
+};

--- a/src/type.ts
+++ b/src/type.ts
@@ -56,6 +56,18 @@ export type PolymorphicComponent<
 > = React.FC<PolymorphicComponentPropsWithRef<E, VariantOptions<V>>>;
 
 /**
+ * The CSS Component Config type.
+ */
+export interface Config<V> {
+  css?: cssType;
+  variants?: V;
+  compoundVariants?: CompoundVariantType<V>[];
+  defaultVariants?: {
+    [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
+  };
+}
+
+/**
  * CSS can be passed in as either a string or an array of strings.
  */
 export type cssType = string | string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+import { cssType, variantValue } from "./type";
+
+export const findMatchingCompoundVariants = (
+  compoundVariants: {
+    [key: string]: variantValue;
+  }[],
+  props: {
+    [key: string]: variantValue;
+  }
+) =>
+  compoundVariants.filter((compoundVariant) =>
+    Object.keys(compoundVariant).every(
+      (key) => key === "css" || compoundVariant[key] === props[key]
+    )
+  );
+
+export const flattenCss = (css: cssType) =>
+  Array.isArray(css) ? css.join(" ") : css;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -232,7 +232,7 @@ describe("supports more exotic setups", () => {
     expect(ref).toBeCalled();
   });
 
-  it("Should be able to inspect the variants", async () => {
+  it("should be able to inspect the variants", async () => {
     const Button = styled("button", {
       css: "test",
       variants: { primary: { true: "primary" } },
@@ -241,5 +241,15 @@ describe("supports more exotic setups", () => {
     type primaryType = CSSComponentPropType<typeof Button, "primary">;
 
     expectTypeOf<primaryType>().toMatchTypeOf<boolean | undefined>();
+  });
+
+  it("should be able to use existing props as variants", async () => {
+    const Option = styled("option", {
+      css: "test",
+      variants: { selected: { true: "primary" } },
+    });
+    const { container } = render(<Option selected>Option 1</Option>);
+
+    expect(container.firstChild).toHaveClass("primary");
   });
 });


### PR DESCRIPTION
Compound Variants config are now typed better. E.g.

```tsx
const Button = styled("button", {
  variants: {
    primary: {
      true: "primary",
    },
    bold: {
      true: "bold",
    },
  },
  compoundVariants: [
    {
      primary: "test", // Will error as value is not valid
      something: "else", // Will error as something is not a variant
      css: "something",
    }
  ]
});
```

Also some marginal refactoring.