### PR TITLE
Change `domPassthrough` behaviour (now just `passthrough`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ const Link = styled(NextLink, {
 });
 ```
 
-### DOM Shielding
+### Passthrough
 
-By default variant values do not end up propagating to the final DOM element. This is to stop React specific runtime errors from occurring. If you do indeed want to pass a variant value to the DOM element, you can use the `domPassthrough` option.
+By default variant values do not end up propagating to the element it is extending and is exclusively used for styling the current component. This is to stop React specific runtime errors from occurring with regards to the DOM. If you do indeed want to pass a variant value to the element you are extending, you can use the `passthrough` option.
 
 In the following example, `readOnly` is an intrinsic HTML attribute that we both want to style, but also continue to pass through to the DOM element.
 
@@ -233,7 +233,7 @@ const Input = styled("input", {
       true: css.disabledStyle,
     },
   },
-  domPassthrough: ["readOnly"],
+  passthrough: ["readOnly"],
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phntms/css-components",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@phntms/css-components",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "glob": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phntms/css-components",
   "description": "At its core, css-components is a simple wrapper around standard CSS. It allows you to write your CSS how you wish then compose them into a component ready to be used in React.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "homepage": "https://github.com/phantomstudios/css-components#readme",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,17 +48,11 @@ export const styled = <
           }
         }
 
-        const isDomNode = typeof element === "string";
         const isVariant =
           config?.variants && config.variants.hasOwnProperty(key);
 
         // Only pass through the prop if it's not a variant or been told to pass through
-        if (
-          isDomNode &&
-          isVariant &&
-          !config?.domPassthrough?.includes(key as keyof V)
-        )
-          return;
+        if (isVariant && !config?.passthrough?.includes(key as keyof V)) return;
 
         componentProps[key] = mergedProps[key];
       });

--- a/src/type.ts
+++ b/src/type.ts
@@ -67,7 +67,7 @@ export interface CSSComponentConfig<V> {
   defaultVariants?: {
     [Property in keyof V]?: BooleanIfStringBoolean<keyof V[Property]>;
   };
-  domPassthrough?: (keyof V)[];
+  passthrough?: (keyof V)[];
 }
 
 /**

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -37,6 +37,15 @@ describe("Basic functionality", () => {
     expect(container.firstChild).toHaveClass("summary");
   });
 
+  it("should pass through classNames for composed css-components", async () => {
+    const BaseParagraph = styled("p", { css: "baseParagraph" });
+    const Paragraph = styled(BaseParagraph, { css: "paragraph" });
+    const { container } = render(<Paragraph>Hello</Paragraph>);
+
+    expect(container.firstChild).toHaveClass("baseParagraph");
+    expect(container.firstChild).toHaveClass("paragraph");
+  });
+
   it("should pass through multiple children", async () => {
     const Article = styled("article");
     const { container } = render(
@@ -328,6 +337,7 @@ describe("supports inheritance", () => {
       variants: {
         big: { true: "checkoutButtonBig" },
       },
+      passthrough: ["big"],
     });
 
     const { container } = render(<CheckoutButton big />);
@@ -416,7 +426,7 @@ describe("supports inheritance", () => {
       variants: {
         type: { text: "textInput" },
       },
-      domPassthrough: ["type"],
+      passthrough: ["type"],
     });
 
     const { container } = render(<Input type="text" />);
@@ -432,7 +442,7 @@ describe("supports inheritance", () => {
       variants: {
         readOnly: { true: "readOnly" },
       },
-      domPassthrough: ["readOnly"],
+      passthrough: ["readOnly"],
     });
 
     const { container } = render(<Input type="text" readOnly />);


### PR DESCRIPTION
This PR changes the behavior of `domPassthrough` and now blocks all variants by default when extending elements/components, regardless of whether they are DOM elements or not. This is a breaking change for projects using `domPassthrough` as it has been renamed to just `passthrough`.

Previously, if an extended element was a component rather than a DOM element, there was no way to stop variant props from ending up on the DOM. The new behavior fixes this issue.

```tsx
const BaseButton = styled("button", {
  css: "baseButton",
  variants: {
    type: { rectangle: "baseButtonRectangle", circle: "baseButtonCircle" },
  },
});

const Button = styled(BaseButton, {
  css: "button",
  variants: {
    type: { rectangle: "buttonRectangle", circle: "buttonCircle" },
  },
});
```

In the given code example, by default, neither `baseButtonRectangle` nor `baseButtonCircle` will be set because all variants are blocked. To resolve this, you need to explicitly specify that the variant prop should pass through using the passthrough prop, as demonstrated in the code example provided.

```tsx
const BaseButton = styled("button", {
  css: "baseButton",
  variants: {
    type: { rectangle: "baseButtonRectangle", circle: "baseButtonCircle" },
  },
});

const Button = styled(BaseButton, {
  css: "button",
  variants: {
    type: { rectangle: "buttonRectangle", circle: "buttonCircle" },
  },
  passthrough: ["type"],
});
```

Furthermore, while the level of shielding provided by this mechanism may seem overly prescriptive, it is intended to address issues that commonly plague other CSS frameworks like styled-components, which often require workarounds like using $type="circle". Although the mechanism could be removed, doing so would likely result in similar issues.